### PR TITLE
ci: align with modern-di

### DIFF
--- a/.github/workflows/_checks.yml
+++ b/.github/workflows/_checks.yml
@@ -1,0 +1,44 @@
+name: checks
+on:
+  workflow_call: {}
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: extractions/setup-just@v4
+      - uses: astral-sh/setup-uv@v8.2.0
+        with:
+          enable-cache: true
+          cache-dependency-glob: "**/pyproject.toml"
+      - run: uv python install 3.13
+      - run: just install lint-ci
+
+  pytest:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:latest
+        env:
+          POSTGRES_DB: postgres
+          POSTGRES_PASSWORD: password
+          POSTGRES_USER: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    steps:
+      - uses: actions/checkout@v6
+      - uses: astral-sh/setup-uv@v8.2.0
+      - run: uv python install 3.13
+      - run: |
+          uv sync --all-extras --no-install-project
+          uv run --no-sync pytest . --cov=. --cov-report xml
+        env:
+          PYTHONDONTWRITEBYTECODE: 1
+          PYTHONUNBUFFERED: 1
+          DB_DSN: postgresql+asyncpg://postgres:password@127.0.0.1/postgres

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,4 @@
 name: main
-
 on:
   push:
     branches:
@@ -11,51 +10,5 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  lint:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: extractions/setup-just@v2
-      - uses: astral-sh/setup-uv@v3
-        with:
-          enable-cache: true
-          cache-dependency-glob: "**/pyproject.toml"
-      - run: uv python install 3.13
-      - run: just install lint-ci
-
-  pytest:
-    runs-on: ubuntu-latest
-    services:
-      postgres:
-        image: postgres:latest
-        env:
-          POSTGRES_DB: postgres
-          POSTGRES_PASSWORD: password
-          POSTGRES_USER: postgres
-        ports:
-          - 5432:5432
-        # Set health checks to wait until postgres has started
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-    steps:
-      - uses: actions/checkout@v3
-      - uses: astral-sh/setup-uv@v3
-      - run: uv python install 3.13
-      - run: |
-          uv sync --all-extras --no-install-project
-          uv run --no-sync pytest . --cov=. --cov-report xml
-        env:
-          PYTHONDONTWRITEBYTECODE: 1
-          PYTHONUNBUFFERED: 1
-          DB_DSN: postgresql+asyncpg://postgres:password@127.0.0.1/postgres
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4.0.1
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-        with:
-          files: ./coverage.xml
-          flags: unittests
-          name: codecov-${{ matrix.python-version }}
+  checks:
+    uses: ./.github/workflows/_checks.yml

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,9 +9,9 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: extractions/setup-just@v2
-      - uses: astral-sh/setup-uv@v3
+      - uses: actions/checkout@v6
+      - uses: extractions/setup-just@v4
+      - uses: astral-sh/setup-uv@v8.2.0
       - run: just publish
         env:
           PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}


### PR DESCRIPTION
## Summary

Aligns CI with [modern-di](https://github.com/modern-python/modern-di)'s pattern. Mirrors the [lite-bootstrap migration](https://github.com/modern-python/lite-bootstrap/pull/115).

- Bump pins to `checkout@v6` / `setup-just@v4` / `setup-uv@v8.2.0`. Also resolves an internal inconsistency where the pytest job used `checkout@v3` while lint used `@v4`.
- Drop codecov upload step. Coverage floor is still enforced via `--cov-fail-under` in `pyproject.toml`; modern-di also dropped codecov.
- Split `ci.yml` into thin trigger wrapper + reusable `_checks.yml`. The pytest job preserves its existing raw `uv sync` + `uv run pytest` pattern (does not use `just`) and the postgres services block — only the surrounding workflow scaffolding changed.

## Test plan

- [ ] PR CI green (pytest runs only on 3.13 in this repo; not a matrix).
- [ ] After merge, `CODECOV_TOKEN` repo secret can be deleted — operator follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)