### PR TITLE
docs: compact CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,20 +4,14 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Commands
 
-```bash
-just install       # uv lock --upgrade && uv sync
-just lint          # ruff format + eof-fixer (auto-fix)
-just lint-ci       # ruff check only (no fixes)
-just build         # build docker image
-just test          # run pytest inside docker (requires postgres)
-just               # install lint build test (full pipeline)
-```
+Recipes live in the `Justfile` (`just --list`); the bare `just` runs the full
+`install lint build test` pipeline. Non-obvious notes:
 
-To run tests locally without Docker, set `DB_DSN` and run:
-```bash
-uv run pytest
-uv run pytest tests/test_retry.py::test_postgres_retry  # single test
-```
+- `just test` runs pytest inside Docker (needs the compose postgres). To run
+  locally without Docker, set `DB_DSN` and use `uv run pytest` directly
+  (e.g. `uv run pytest tests/test_retry.py::test_postgres_retry` for one test).
+- `just lint` auto-fixes (eof-fixer, ruff format, ruff check --fix, ty check);
+  `just lint-ci` is the same checks in no-fix/`--check` mode (CI gate).
 
 The CI `DB_DSN` format: `postgresql+asyncpg://postgres:postgres@localhost:5432/postgres`
 
@@ -37,6 +31,6 @@ The package (`db_retry/`) exposes five public symbols via `__init__.py`:
 
 ## Linting / Type Checking
 
-Ruff is configured with `select = ["ALL"]` plus specific exclusions. Line length is 120. Run `just lint` before committing.
-
-Type checking uses `ty` (not mypy). In code, use `ty: ignore` for suppression comments (not `type: ignore`).
+Ruff is configured with `select = ["ALL"]` plus specific exclusions; line length
+is 120. Type checking uses `ty` (not mypy) — in code, use `ty: ignore` for
+suppression comments (not `type: ignore`).


### PR DESCRIPTION
Light compaction of CLAUDE.md (Commands section was stale vs. the Justfile).

## What changed
- **Commands**: replaced the verbatim recipe list with a `Justfile` (`just --list`) pointer plus only the non-obvious "which to use when" notes. The old list had drifted — `just install`, `just lint`, and `just lint-ci` descriptions no longer matched the actual recipes (e.g. `lint-ci` runs eof-fixer/ruff-format/ruff-check/ty, not "ruff check only").
- **Linting/Type Checking**: dropped the now-redundant "run `just lint` before committing" line; kept the load-bearing ruff config, line-length, and `ty: ignore` facts.
- Left the repo-specific **Architecture** section (5 public symbols) untouched — this package has no `architecture/` truth home, so that detail legitimately lives here.

## Verification
`just lint-ci` green (eof-fixer, ruff format, ruff check, ty all pass). Only CLAUDE.md changed.