### PR TITLE
docs: add brand logo banner to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,10 @@
-# db-retry
+<p align="center">
+  <picture>
+    <source media="(prefers-color-scheme: dark)"  srcset="https://raw.githubusercontent.com/modern-python/.github/main/brand/projects/db-retry/lockup-dark.svg">
+    <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/modern-python/.github/main/brand/projects/db-retry/lockup-light.svg">
+    <img alt="db-retry" src="https://raw.githubusercontent.com/modern-python/.github/main/brand/projects/db-retry/lockup.png" width="420">
+  </picture>
+</p>
 
 [![PyPI version](https://img.shields.io/pypi/v/db-retry.svg)](https://pypi.org/project/db-retry/)
 [![Supported Python versions](https://img.shields.io/pypi/pyversions/db-retry.svg)](https://pypi.org/project/db-retry/)


### PR DESCRIPTION
Add the modern-python brand logo banner to the top of README.md, replacing the leading H1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)