### PR TITLE
ci: publish to PyPI via Trusted Publishing (OIDC)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,13 +11,15 @@ on:
       - '[0-9]+.[0-9]+.[0-9]+'               # stable:      2.7.2
       - '[0-9]+.[0-9]+.[0-9]+[a-z]+[0-9]+'   # pre-release: 2.0.0rc1, 4.0.0a2
 
-# Needed for softprops/action-gh-release to create the GitHub Release.
+# contents: write -> create the GitHub Release; id-token: write -> OIDC for PyPI Trusted Publishing.
 permissions:
   contents: write
+  id-token: write
 
 jobs:
   release:
     runs-on: ubuntu-latest
+    environment: pypi  # scopes the PyPI Trusted Publisher; hook for approval rules
     steps:
       - uses: actions/checkout@v6
       - uses: extractions/setup-just@v4
@@ -26,9 +28,9 @@ jobs:
       # PyPI is irreversible, so it runs FIRST: if it fails the job stops and no
       # GitHub Release is created advertising a version that never reached PyPI.
       # `just publish` derives the version from $GITHUB_REF_NAME (the tag name).
+      # Auth via PyPI Trusted Publishing (OIDC); no PYPI_TOKEN. Needs a Trusted
+      # Publisher on the db-retry PyPI project (env: pypi, workflow: release.yml).
       - run: just publish
-        env:
-          PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
 
       # Description source: planning/releases/<tag>.md if present (verbatim, no
       # auto-changelog appended); otherwise GitHub's generated notes. A tag with

--- a/Justfile
+++ b/Justfile
@@ -35,8 +35,9 @@ index:
 check-planning:
     uv run python planning/index.py --check
 
+# Auth via PyPI Trusted Publishing (OIDC); uv publish auto-detects the CI id-token.
 publish:
     rm -rf dist
     uv version $GITHUB_REF_NAME
     uv build
-    uv publish --token $PYPI_TOKEN
+    uv publish

--- a/planning/releases/0.5.1.md
+++ b/planning/releases/0.5.1.md
@@ -1,0 +1,11 @@
+# db-retry 0.5.1 — release pipeline on PyPI Trusted Publishing
+
+No library changes. The package is identical to 0.5.0; this release exercises the new publish path end-to-end.
+
+## CI
+
+- Releases now authenticate to PyPI via **Trusted Publishing (OIDC)** instead of a long-lived `PYPI_TOKEN` secret. `uv publish` auto-detects the GitHub Actions id-token; the release job runs under a `pypi` environment that scopes the trusted publisher (#29).
+
+## Downstream
+
+No action required. Nothing about the installed package changes.


### PR DESCRIPTION
## What

Replace the long-lived `PYPI_TOKEN` secret with PyPI Trusted Publishing (OIDC).

## Changes

- `release.yml`: add `id-token: write`, run the job under a `pypi` environment, drop the `PYPI_TOKEN` env from the publish step.
- `Justfile`: `uv publish --token $PYPI_TOKEN` -> `uv publish`.

## Why

No credential to leak or rotate; OIDC tokens are short-lived and scoped to this repo + workflow.

## Required before the next release tag (maintainer, PyPI-side)

1. PyPI -> db-retry project -> Publishing -> add a Trusted Publisher: owner `modern-python`, repo `db-retry`, workflow `release.yml`, environment `pypi`.
2. Create the `pypi` environment under repo Settings -> Environments (may already exist).
3. After the first OIDC release succeeds, delete the `PYPI_TOKEN` repo secret.